### PR TITLE
Silas

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -24,7 +24,7 @@ import glob
 
 
 
-__author__ = 'Chris Rands'
+__author__ = 'Chris Rands, Silas Kieser'
 
 # Inputs
 INPUT_DIR = config['in_dir']

--- a/Snakefile
+++ b/Snakefile
@@ -48,6 +48,8 @@ if len(INPUT_TARGETS)==0:
 elif len(INPUT_TARGETS) > 500:
     raise Exception(" I don't now if I can handle {} files".format(len(INPUT_TARGETS)))
 
+
+
 rule all:
     input:
         "mmSeqs2.done",
@@ -61,7 +63,7 @@ rule mmseqs:
         expand('mmseqs/input/{input_targets}.trimmed.db', input_targets=INPUT_TARGETS),
         expand('mmseqs/profile/{input_targets}.profile', input_targets=INPUT_TARGETS),
         expand('mmseqs/pssm/{input_targets}.pssm', input_targets=INPUT_TARGETS),
-        expand('mmseqs/profile/{input_targets}.profile', input_targets=INPUT_TARGETS),
+        expand('mmseqs/profile/{input_targets}.profile.k5s7', input_targets=INPUT_TARGETS),
         expand('mmseqs/scores/{category}/{input_targets}.scores', category=['negative','train'] ,input_targets=INPUT_TARGETS)
     output:
         touch("mmSeqs2.done")

--- a/Snakefile
+++ b/Snakefile
@@ -57,11 +57,11 @@ rule all:
 rule mmseqs:
     input:
         # MMSeqs2 Profiles
-        expand('msa_trim_stockholm/{input_targets}.trim.al.sth', input_targets=INPUT_TARGETS),
-        expand('msa_trim_mmseqs_db/{input_targets}.trim.al.db', input_targets=INPUT_TARGETS),
-        expand('msa_trim_mmseqs_profile/{input_targets}.profile', input_targets=INPUT_TARGETS),
-        expand('msa_trim_mmseqs_pssm/{input_targets}.pssm', input_targets=INPUT_TARGETS),
-        expand('msa_trim_mmseqs_profile/{input_targets}.profile.sk5', input_targets=INPUT_TARGETS),
+        expand('mmseqs/input/{input_targets}.trimmed.sth', input_targets=INPUT_TARGETS),
+        expand('mmseqs/input/{input_targets}.trimmed.db', input_targets=INPUT_TARGETS),
+        expand('mmseqs/profile/{input_targets}.profile', input_targets=INPUT_TARGETS),
+        expand('mmseqs/pssm/{input_targets}.pssm', input_targets=INPUT_TARGETS),
+        expand('mmseqs/profile/{input_targets}.profile.sk5', input_targets=INPUT_TARGETS),
         expand('mmseqs/scores/{category}/{input_targets}.scores', category=['negative','train'] ,input_targets=INPUT_TARGETS)
     output:
         touch("mmSeqs2.done")
@@ -88,4 +88,4 @@ rule all_align:
     input:
         # Alignments
         expand('msa/{input_targets}.al.fa', input_targets=INPUT_TARGETS),
-        expand('msa_trim/{input_targets}.trim.al.fa', input_targets=INPUT_TARGETS)
+        expand('msa/{input_targets}.trim.al.fa', input_targets=INPUT_TARGETS)

--- a/Snakefile
+++ b/Snakefile
@@ -61,7 +61,7 @@ rule mmseqs:
         expand('mmseqs/input/{input_targets}.trimmed.db', input_targets=INPUT_TARGETS),
         expand('mmseqs/profile/{input_targets}.profile', input_targets=INPUT_TARGETS),
         expand('mmseqs/pssm/{input_targets}.pssm', input_targets=INPUT_TARGETS),
-        expand('mmseqs/profile/{input_targets}.profile.sk5', input_targets=INPUT_TARGETS),
+        expand('mmseqs/profile/{input_targets}.profile', input_targets=INPUT_TARGETS),
         expand('mmseqs/scores/{category}/{input_targets}.scores', category=['negative','train'] ,input_targets=INPUT_TARGETS)
     output:
         touch("mmSeqs2.done")

--- a/Snakefile
+++ b/Snakefile
@@ -33,7 +33,7 @@ SCRIPTS_DIR =  os.path.join(os.path.dirname(os.path.abspath(workflow.snakefile))
 sys.path.append(SCRIPTS_DIR)
 # TODO: one could also use the scripts directive, wich automaticaly ajusts the path from the Snakefile.
 
-
+#TODO: check if files exist
 
 if config.get('target_names') is None:
 
@@ -48,23 +48,46 @@ if len(INPUT_TARGETS)==0:
 elif len(INPUT_TARGETS) > 500:
     raise Exception(" I don't now if I can handle {} files".format(len(INPUT_TARGETS)))
 
+if config.get('querry_dir') is not None:
+    QUERRY_DIR = config.get('querry_dir')
+else:
+    QUERRY_DIR = config['in_dir']
 
+
+if config.get('querry_names') is not None:
+    INPUT_QUERRIES = config.get('querry_names')
+
+    print(f"Querries: {INPUT_QUERRIES} ")
+
+if config.get('tmpdir') is None:
+    config['tmpdir'] = 'tmp'
+
+if not os.path.exists(config['tmpdir']): os.makedirs(config['tmpdir'])
+
+
+
+
+
+# Rules
+
+
+if config.get('querry_names') is not None:
+    rule mmseqs:
+        input:
+            expand('mmseqs/search/{querry}/{input_targets}.m8',querry = INPUT_QUERRIES, input_targets= INPUT_TARGETS)
 
 rule all:
     input:
         "mmSeqs2.done",
         #"hmmer.done"
 
-# Rules
-rule mmseqs:
+rule mmseqs_evaluate:
     input:
         # MMSeqs2 Profiles
-        expand('mmseqs/input/{input_targets}.trimmed.sth', input_targets=INPUT_TARGETS),
-        expand('mmseqs/input/{input_targets}.trimmed.db', input_targets=INPUT_TARGETS),
         expand('mmseqs/profile/{input_targets}.profile', input_targets=INPUT_TARGETS),
         expand('mmseqs/pssm/{input_targets}.pssm', input_targets=INPUT_TARGETS),
-        expand('mmseqs/profile/{input_targets}.profile.k5s7', input_targets=INPUT_TARGETS),
-        expand('mmseqs/scores/{category}/{input_targets}.scores', category=['negative','train'] ,input_targets=INPUT_TARGETS)
+        #expand('mmseqs/profile/{input_targets}.profile.k5s7', input_targets=INPUT_TARGETS),
+        expand('mmseqs/scores/{category}/{input_targets}.m8', category=['negative','train'] ,input_targets=INPUT_TARGETS)
     output:
         touch("mmSeqs2.done")
 include: "rules/alignment.smk"

--- a/rules/alignment.smk
+++ b/rules/alignment.smk
@@ -30,7 +30,7 @@ rule trim:
     input:
         rules.align.output
     output:
-        'msa_trim/{input_targets}.trim.al.fa'
+        'msa/{input_targets}.trim.al.fa'
     conda: "../envs/alignment.yaml"
     params: # this should ho in the config or so
         params= [f'-{key} {value}' for key,value in config['trimal'].items()]

--- a/rules/mmseqs.smk
+++ b/rules/mmseqs.smk
@@ -4,7 +4,7 @@ rule MSAfasta_to_stockholm:
     input:
         rules.trim.output
     output:
-        'msa_trim_stockholm/{input_targets}.trim.al.sth'
+        'mmseqs/input/{input_targets}.trimmed.sth'
     shell:
         'python3 %s/faMSA_to_StockholmMSA.py {input} False {output}' %(SCRIPTS_DIR)
 
@@ -12,7 +12,7 @@ rule stockholm_to_MSAdb:
     input:
         rules.MSAfasta_to_stockholm.output
     output:
-        'msa_trim_mmseqs_db/{input_targets}.trim.al.db'
+        'mmseqs/input/{input_targets}.trimmed.db'
     conda: "../envs/mmseqs.yaml"
     shell:
         'mmseqs convertmsa {input} {output}'
@@ -21,7 +21,7 @@ rule MSAdb_to_profile:
     input:
         rules.stockholm_to_MSAdb.output
     output:
-        'msa_trim_mmseqs_profile/{input_targets}.profile'
+        'mmseqs/profile/{input_targets}.profile'
     conda: "../envs/mmseqs.yaml"
     shell:
         "mmseqs msa2profile {input} {output} "
@@ -31,7 +31,7 @@ rule profile_to_pssm:
     input:
         rules.MSAdb_to_profile.output
     output:
-        'msa_trim_mmseqs_pssm/{input_targets}.pssm'
+        'mmseqs/pssm/{input_targets}.pssm'
     conda: "../envs/mmseqs.yaml"
     shell:
         'mmseqs  profile2pssm {input} {output} --threads {threads}'
@@ -40,7 +40,7 @@ rule profile_to_indexdb:
     input:
         rules.MSAdb_to_profile.output
     output:
-        out1 = 'msa_trim_mmseqs_profile/{input_targets}.profile.sk5',
+        out1 = 'mmseqs/profile/{input_targets}.profile',
         tmp = temp('{input_targets}_tmp1/')
     conda: "../envs/mmseqs.yaml"
     shell:
@@ -80,7 +80,7 @@ rule score_mmseqs_train:
     shell:
         'mmseqs search {input.fasta} {input.profile} {output.out} {output.tmp}'
 
-
+## this rule works also for hmmer
 def get_all_targets_but(INPUT_TARGETS,remove_this):
 
     return [ x for x in INPUT_TARGETS if not x==remove_this ]
@@ -132,3 +132,6 @@ rule score_mmseqs:
     conda: "../envs/mmseqs.yaml"
     shell:
         'mmseqs search -e 1e10  {input.fasta} {input.profile} {output.out} {output.tmp}'
+
+rule merge_profiles:
+    input:

--- a/rules/mmseqs.smk
+++ b/rules/mmseqs.smk
@@ -40,13 +40,13 @@ rule profile_to_indexdb:
     input:
         rules.MSAdb_to_profile.output
     output:
-        out1 = 'mmseqs/profile/{input_targets}.profile',
+        out1 = 'mmseqs/profile/{input_targets}.profile.k5s7',
         tmp = temp('{input_targets}_tmp1/')
     conda: "../envs/mmseqs.yaml"
     shell:
         'mmseqs createindex {input} {output.tmp} -k 5 -s 7'
 
-rule make_index:
+rule make_db:
     input:
         "{folder}/{file}.fasta"
     output:
@@ -55,7 +55,7 @@ rule make_index:
     shell:
         'mmseqs createdb {input} {output}'
 
-rule make_index_fa:
+rule make_db_fa:
     input:
         "{folder}/{file}.fa"
     output:
@@ -132,6 +132,3 @@ rule score_mmseqs:
     conda: "../envs/mmseqs.yaml"
     shell:
         'mmseqs search -e 1e10  {input.fasta} {input.profile} {output.out} {output.tmp}'
-
-rule merge_profiles:
-    input:

--- a/rules/mmseqs.smk
+++ b/rules/mmseqs.smk
@@ -36,15 +36,15 @@ rule profile_to_pssm:
     shell:
         'mmseqs  profile2pssm {input} {output} --threads {threads}'
 
-rule profile_to_indexdb:
-    input:
-        rules.MSAdb_to_profile.output
-    output:
-        out1 = 'mmseqs/profile/{input_targets}.profile.k5s7',
-        tmp = temp('{input_targets}_tmp1/')
-    conda: "../envs/mmseqs.yaml"
-    shell:
-        'mmseqs createindex {input} {output.tmp} -k 5 -s 7'
+# rule profile_to_indexdb:
+#     input:
+#         rules.MSAdb_to_profile.output
+#     output:
+#         out = 'mmseqs/profile/{input_targets}.profile.index',
+#         tmp = temp('{input_targets}_tmp1/')
+#     conda: "../envs/mmseqs.yaml"
+#     shell:
+#         'mmseqs createindex {input} {output.tmp} -k 5 -s 7'
 
 rule make_db:
     input:
@@ -64,6 +64,39 @@ rule make_db_fa:
     shell:
         'mmseqs createdb {input} {output}'
 
+rule search_mmseqs:
+    input:
+        profile = rules.MSAdb_to_profile.output,
+        fasta = os.path.join(QUERRY_DIR, '{querry}.db')
+    output:
+        db = temp('mmseqs/search/{querry}/{input_targets}.db'),
+        index = temp('mmseqs/search/{querry}/{input_targets}.db.index'),
+        tsv = 'mmseqs/search/{querry}/{input_targets}.m8',
+    conda: "../envs/mmseqs.yaml"
+    shell:
+        """
+            mmseqs search {input.fasta} {input.profile} {output.db} {config[tmpdir]}
+
+            mmseqs convertalis {input.fasta} {input.profile} {output.db} {output.tsv}
+        """
+
+
+
+
+# rule merge_search_results:
+#     input:
+#         results = lambda wc: expand(rules.search_mmseqs.output.out, input_targets =INPUT_TARGETS, **wc),
+#         index = lambda wc: expand(rules.search_mmseqs.output.index, input_targets =INPUT_TARGETS, **wc),
+#         fasta = os.path.join(QUERRY_DIR, '{querry}.db')
+#     output:
+#         out = 'mmseqs/search/{querry}.txt',
+#         index = 'mmseqs/search/{querry}.txt.index'
+#     params:
+#         names = ','.join(INPUT_TARGETS)
+#     conda: "../envs/mmseqs.yaml"
+#     shell:
+#         'mmseqs mergedbs {input.fasta} {output.out} {input.results} --prefixes {params.names}'
+
 
 ## Evaluation
 
@@ -74,52 +107,85 @@ rule score_mmseqs_train:
         profile = rules.MSAdb_to_profile.output,
         fasta = os.path.join(INPUT_DIR, '{input_targets}.db')
     output:
-        out = 'mmseqs/scores/train/{input_targets}.scores',
-        tmp = temp('{input_targets}_tmp2/')
+        db = temp('mmseqs/scores/train/{input_targets}.scores'),
+        index = temp('mmseqs/scores/train/{input_targets}.scores.index'),
+        tsv = 'mmseqs/scores/train/{input_targets}.m8',
     conda: "../envs/mmseqs.yaml"
     shell:
-        'mmseqs search {input.fasta} {input.profile} {output.out} {output.tmp}'
+        """
+
+            mmseqs search {input.fasta} {input.profile} {output.db} {config[tmpdir]}
+
+            mmseqs convertalis {input.fasta} {input.profile} {output.db} {output.tsv}
+
+        """
 
 ## this rule works also for hmmer
 def get_all_targets_but(INPUT_TARGETS,remove_this):
 
     return [ x for x in INPUT_TARGETS if not x==remove_this ]
 
+from Bio import SeqIO
+import numpy as np
+
+def subsample_fasta(input_fasta, N, output_fasta= None):
+    """
+        Subsample sequences in file. If N > than n seqs in file all sequences are retreved.
+        If outputfile is not specified, a list of BioPython Seqs are given.
+    """
+    seqs = list(SeqIO.parse(input_fasta,'fasta'))
+
+    if N >= len(seqs):
+        outseqs = seqs
+    else:
+        # subsample
+        outseqs= [seqs[j] for j in np.random.randint(0,len(seqs), N)]
+
+    if output_fasta is None:
+        return outseqs
+    else:
+        SeqIO.write(outseqs,output_fasta,'fasta')
+
+
 
 rule get_negative_evaluation_fasta:
     input:
         fasta = lambda wc: expand("{in_dir}/{targets}.{suffix}",
-                          targets = get_all_targets_but(INPUT_TARGETS, wc.input_targets),**config)
+                          targets = get_all_targets_but(INPUT_TARGETS, wc.input_targets),
+                          in_dir=config['in_dir'],suffix=config['suffix'])
     output:
         fasta= 'mmseqs/evaluation_seq/{input_targets}.negative.fasta',
     params:
         n_negatives = 2000
-    run:         # TODO: subsample
-        import numpy as np
-        from Bio import SeqIO
+    run:
 
-        # random int +- 1
-        n_samples_per_file = lambda :  int(np.random.randn(1) + params.n_negatives / len(input.fasta) )
 
-        selected_sequences =[]
+        if len(input.fasta) < 10:
+            shell("cat {input.fasta} > {output.fasta}")
+        else:
+            #subsample
 
-        i=0
-        while len(selected_sequences) < params.n_negatives:
+            # random int +- 1
+            n_samples_per_file = lambda : int(np.random.randn(1) + params.n_negatives / len(input.fasta) )
 
-            # cycle trough input files
-            seq_file = input.fasta[i % len(input.fasta) ]
+            selected_sequences =[]
 
-            i+=1
+            i=0
+            while len(selected_sequences) <= params.n_negatives:
 
-            seqs = list(SeqIO.parse(seq_file,'fasta'))
+            # this acctually may subsample several times the same sequence
 
-            n_select= min([n_samples_per_file(), len(seqs), params.n_negatives-len(selected_sequences) ])
+                # cycle trough input files
+                seq_file = input.fasta[i % len(input.fasta) ]
 
-            selected_sequences += [seqs[j] for j in np.random.randint(0,len(seqs), n_select)]
+                i+=1
+                n_select= min([n_samples_per_file(), params.n_negatives-len(selected_sequences) ])
 
-        assert len(selected_sequences) == params.n_negatives
+                selected_sequences += subsample_fasta(seq_file, n_select)
 
-        SeqIO.write(selected_sequences,output.fasta,'fasta')
+            assert len(selected_sequences) == params.n_negatives
+
+            SeqIO.write(selected_sequences,output.fasta,'fasta')
 
 
 rule score_mmseqs:
@@ -127,8 +193,14 @@ rule score_mmseqs:
         profile = rules.MSAdb_to_profile.output,
         fasta = 'mmseqs/evaluation_seq/{input_targets}.{classify_group}.db'
     output:
-        out = 'mmseqs/scores/{classify_group}/{input_targets}.scores',
-        tmp = temp('{input_targets}_{classify_group}_tmp2/')
+        db = temp('mmseqs/scores/{classify_group}/{input_targets}.scores'),
+        index = temp('mmseqs/scores/{classify_group}/{input_targets}.scores.index'),
+        tsv = 'mmseqs/scores/{classify_group}/{input_targets}.m8',
     conda: "../envs/mmseqs.yaml"
     shell:
-        'mmseqs search -e 1e10  {input.fasta} {input.profile} {output.out} {output.tmp}'
+        """
+
+        mmseqs search -e 1e10  {input.fasta} {input.profile} {output.db} {config[tmpdir]}
+        mmseqs convertalis {input.fasta} {input.profile} {output.db} {output.tsv}
+
+        """


### PR DESCRIPTION
- simplified folder names: msa_trim. to msa,
- added querry for mmseqs 
- evaluate mmseqs profiles with train and negative seqs
- possibility to add test sequences, sequences not part of profile.

- deactivated hmmer, but can be run by `snakemake [options] hmmer`

